### PR TITLE
Make admin and user roles permanent

### DIFF
--- a/api/src/main/java/api/components/DbSetup.java
+++ b/api/src/main/java/api/components/DbSetup.java
@@ -39,7 +39,7 @@ public class DbSetup {
     @Value("${api.admin.password:password}")
     private String adminPassword;
 
-    private String[] authorityNames = {
+    private static String[] authorityNames = {
         "AUTHORITY_READ",
         "ROLE_READ",
         "ROLE_WRITE",

--- a/api/src/main/java/api/components/DbSetup.java
+++ b/api/src/main/java/api/components/DbSetup.java
@@ -1,5 +1,6 @@
 package api.components;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,14 @@ public class DbSetup {
     @Value("${api.admin.password:password}")
     private String adminPassword;
 
+    private String[] authorityNames = {
+        "AUTHORITY_READ",
+        "ROLE_READ",
+        "ROLE_WRITE",
+        "USER_READ",
+        "USER_WRITE"
+    };
+
     /**
      * Initialize the database with necessary fields.
      */
@@ -46,29 +55,24 @@ public class DbSetup {
         log.info("Active profile: " + activeProfile);
 
         // Setup Authorities
-        Authority authorityRead = authorityService.find("AUTHORITY_READ")
-            .orElseGet(() -> authorityService.save(Authority.builder().authority("AUTHORITY_READ").build()));
-        Authority userRead = authorityService.find("USER_READ")
-            .orElseGet(() -> authorityService.save(Authority.builder().authority("USER_READ").build()));
-        Authority userWrite = authorityService.find("USER_WRITE")
-            .orElseGet(() -> authorityService.save(Authority.builder().authority("USER_WRITE").build()));
-        Authority roleRead = authorityService.find("ROLE_READ")
-            .orElseGet(() -> authorityService.save(Authority.builder().authority("ROLE_READ").build()));
-        Authority roleWrite = authorityService.find("ROLE_WRITE")
-            .orElseGet(() -> authorityService.save(Authority.builder().authority("ROLE_WRITE").build()));
+        Set<Authority> authorities = new HashSet<>();
+        for (String authorityName : authorityNames) {
+            authorities.add(authorityService.find(authorityName)
+                .orElseGet(() -> authorityService.save(Authority.builder().authority(authorityName).build())));
+        }
 
         // Setup Roles
-        Role adminRole = roleService.find("ADMIN")
+        Role adminRole = roleService.find(RoleService.ADMIN_ROLE_NAME)
             .orElseGet(() -> roleService.save(
                 Role.builder()
-                    .name("ADMIN")
-                    .authorities(Set.of(authorityRead, userRead, userWrite, roleRead, roleWrite))
+                    .name(RoleService.ADMIN_ROLE_NAME)
+                    .authorities(authorities)
                     .build()
             ));
-        Role userRole = roleService.find("USER")
-            .orElseGet(() -> roleService.save(Role.builder().name("USER").build()));
+        Role userRole = roleService.find(RoleService.USER_ROLE_NAME)
+            .orElseGet(() -> roleService.save(Role.builder().name(RoleService.USER_ROLE_NAME).build()));
 
-        // Setup Users
+        // Setup Admin
         userService.find("admin")
             .orElseGet(() -> userService.save(
                 User.builder()

--- a/api/src/main/java/api/controllers/RoleController.java
+++ b/api/src/main/java/api/controllers/RoleController.java
@@ -269,6 +269,13 @@ public class RoleController {
             responseCode = "200"
         ),
         @ApiResponse(
+            responseCode = "400",
+            content = @Content(
+                schema = @Schema(implementation = ErrorDto.class),
+                mediaType = "application/json"
+            )
+        ),
+        @ApiResponse(
             responseCode = "403",
             content = @Content(
                 schema = @Schema(implementation = ErrorDto.class),

--- a/api/src/main/java/api/services/AuthenticationService.java
+++ b/api/src/main/java/api/services/AuthenticationService.java
@@ -43,7 +43,7 @@ public class AuthenticationService {
             throw new DuplicateEntityException("Username '" + registerDto.getUsername() + "' already exists.");
         }
 
-        Role userRole = roleService.get("USER");
+        Role userRole = roleService.get(RoleService.USER_ROLE_NAME);
 
         User user = User.builder()
             .username(registerDto.getUsername())

--- a/api/src/main/java/api/services/RoleService.java
+++ b/api/src/main/java/api/services/RoleService.java
@@ -163,7 +163,7 @@ public class RoleService {
     @Transactional
     public void delete(Role role) {
         if (role.getId() == get(USER_ROLE_NAME).getId() || role.getId() == get(ADMIN_ROLE_NAME).getId()) {
-            throw new IllegalArgumentException("Cannot delete " + role.getId() + " role.");
+            throw new IllegalArgumentException("Role " + role.getId() + " cannot be deleted.");
         }
         detachFromUsers(role);
         roleRepository.delete(role);

--- a/api/src/main/java/api/services/RoleService.java
+++ b/api/src/main/java/api/services/RoleService.java
@@ -25,6 +25,9 @@ public class RoleService {
     @Autowired
     private UserService userService;
 
+    public static final String USER_ROLE_NAME = "USER";
+    public static final String ADMIN_ROLE_NAME = "ADMIN";
+
     /**
      * Find role.
      *
@@ -159,6 +162,9 @@ public class RoleService {
      */
     @Transactional
     public void delete(Role role) {
+        if (role.getId() == get(USER_ROLE_NAME).getId() || role.getId() == get(ADMIN_ROLE_NAME).getId()) {
+            throw new IllegalArgumentException("Cannot delete " + role.getId() + " role.");
+        }
         detachFromUsers(role);
         roleRepository.delete(role);
         log.info("Role deleted: " + role);

--- a/api/src/test/java/api/controllers/RoleControllerTest.java
+++ b/api/src/test/java/api/controllers/RoleControllerTest.java
@@ -873,6 +873,70 @@ public class RoleControllerTest extends BasicContext {
         }
 
         @Test
+        public void should400_whenDeleteAdminRole() {
+            // GIVEN: Admin authentication header
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(adminAuth.getAccessToken());
+            HttpEntity<Void> request = new HttpEntity<>(null, headers);
+
+            // GIVEN: Admin role (change the local versions name for good measure)
+            Role role = roleService.get(RoleService.ADMIN_ROLE_NAME);
+            role.setName("NEW_NAME");
+
+            URI uri = UriComponentsBuilder.fromUriString(url)
+                .path(ENDPOINT)
+                .buildAndExpand(role.getId())
+                .toUri();
+
+            // WHEN: Delete role
+            ResponseEntity<ErrorDto> responseEntity = testRestTemplate.exchange(
+                uri, HttpMethod.DELETE, request, new ParameterizedTypeReference<ErrorDto>() {}
+            );
+
+            // THEN: Responds bad request
+            assertAll(
+                () -> assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode()),
+                () -> assertNotNull(responseEntity.getBody()),
+                () -> assertEquals(clock.instant(), responseEntity.getBody().getTimestamp()),
+                () -> assertEquals(
+                    "Cannot delete " + role.getId() + " role.", responseEntity.getBody().getMessage()
+                )
+            );
+        }
+
+        @Test
+        public void should400_whenDeleteUserRole() {
+            // GIVEN: Admin authentication header
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(adminAuth.getAccessToken());
+            HttpEntity<Void> request = new HttpEntity<>(null, headers);
+
+            // GIVEN: User role (change the local versions name for good measure)
+            Role role = roleService.get(RoleService.USER_ROLE_NAME);
+            role.setName("NEW_NAME");
+
+            URI uri = UriComponentsBuilder.fromUriString(url)
+                .path(ENDPOINT)
+                .buildAndExpand(role.getId())
+                .toUri();
+
+            // WHEN: Delete role
+            ResponseEntity<ErrorDto> responseEntity = testRestTemplate.exchange(
+                uri, HttpMethod.DELETE, request, new ParameterizedTypeReference<ErrorDto>() {}
+            );
+
+            // THEN: Responds bad request
+            assertAll(
+                () -> assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode()),
+                () -> assertNotNull(responseEntity.getBody()),
+                () -> assertEquals(clock.instant(), responseEntity.getBody().getTimestamp()),
+                () -> assertEquals(
+                    "Cannot delete " + role.getId() + " role.", responseEntity.getBody().getMessage()
+                )
+            );
+        }
+
+        @Test
         public void should403_whenUnauthorized() {
             // GIVEN: New role exists
             String roleName = "role_" + UUID.randomUUID();

--- a/api/src/test/java/api/controllers/RoleControllerTest.java
+++ b/api/src/test/java/api/controllers/RoleControllerTest.java
@@ -899,7 +899,7 @@ public class RoleControllerTest extends BasicContext {
                 () -> assertNotNull(responseEntity.getBody()),
                 () -> assertEquals(clock.instant(), responseEntity.getBody().getTimestamp()),
                 () -> assertEquals(
-                    "Cannot delete " + role.getId() + " role.", responseEntity.getBody().getMessage()
+                    "Role " + role.getId() + " cannot be deleted.", responseEntity.getBody().getMessage()
                 )
             );
         }
@@ -931,7 +931,7 @@ public class RoleControllerTest extends BasicContext {
                 () -> assertNotNull(responseEntity.getBody()),
                 () -> assertEquals(clock.instant(), responseEntity.getBody().getTimestamp()),
                 () -> assertEquals(
-                    "Cannot delete " + role.getId() + " role.", responseEntity.getBody().getMessage()
+                    "Role " + role.getId() + " cannot be deleted.", responseEntity.getBody().getMessage()
                 )
             );
         }


### PR DESCRIPTION
**High-level Overview**
In the steps toward making our system incapable of reaching an invalid state, we need to ensure that the `ADMIN` and `USER` roles created by `DbSetup` cannot be deleted. 

**Description**
If a user attempts to remove either role `ADMIN` or `USER`, they should receive a 400 status code.

**Tests Needed**
[ ] Unit Tests
[x] Integration Tests
[ ] E2E Tests

**Acceptance Criteria**
The `ADMIN` and `USER` roles can no longer be deleted.

**Dev Notes**
I would suggest doing this at the service level. It might be easier/better to combine the delete methods into one, where the delete by id just calls the delete by entity. 