### PR TITLE
Improve api cache workflow

### DIFF
--- a/.github/workflows/api-cache.yml
+++ b/.github/workflows/api-cache.yml
@@ -21,4 +21,11 @@ jobs:
     - name: Full Run
       if: steps.setup-maven.outputs.cache-hit != 'true'
       working-directory: ./api
-      run: ./mvnw -B verify test package site
+      run: |
+        ./mvnw -B dependency:go-offline
+        ./mvnw -B dependency:resolve dependency:resolve-plugins
+        ./mvnw -B -Pdev dependency:go-offline
+        ./mvnw -B -Pdev dependency:resolve dependency:resolve-plugins
+        ./mvnw -B -Pprod dependency:go-offline
+        ./mvnw -B -Pprod dependency:resolve dependency:resolve-plugins
+        ./mvnw -B verify test package site


### PR DESCRIPTION
**Describe the bug**
The `api-cache` stage of the workflow is meant to cache all maven dependencies, but it doesn't cache the ones necessary for the production profile.

**To Reproduce**
Run the workflow and observe that during the `api-test` `prod` job, a postgresql dependency is downloaded.

**Expected behavior**
No maven dependencies should need to be downloaded in any stage other than `api-cache`

**Screenshots (if applicable)**
<img width="1103" height="208" alt="Image" src="https://github.com/user-attachments/assets/46614529-f2c5-40cd-8b70-84ee7677459e" />

**Additional context**
I think this specific case was fixed by https://github.com/GitTor-ISU/GitTor-App/pull/30, but this should prevent future cases.