### PR TITLE
Implement pi deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy
+
+on:
+  workflow_call:
+
+jobs:
+  pi:
+    runs-on: pi
+    continue-on-error: true
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Fetch
+      run: git fetch origin pi-deploy-config
+
+    - name: Update Configuration
+      run: git merge origin/pi-deploy-config
+
+    - name: Deploy
+      working-directory: ./tools
+      run: ./run-docker-prod.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,3 +45,6 @@ jobs:
       - ui-build
       - ui-test
     uses: ./.github/workflows/report.yml
+
+  deploy:
+    uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,4 +1,4 @@
-name: Report pages
+name: Report
 
 on:
   workflow_call:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.6</version>
+    <version>3.5.7</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>4.9.6</version>
+      <version>4.9.8</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
**High-level Overview**
Get a workflow to automatically host our website on Isaac's raspberry pi.

**Description**
Add the raspberry pi as a runner an have it start the docker production run whenever the main branch is changed.

**Tests Needed**
[ ] Unit Tests
[ ] Integration Tests
[ ] E2E Tests

**Acceptance Criteria**
Whenever the main branch is changed, the raspberry pi web hosting is updated.

**Dev Notes**
This may not be the same forever, but right now it's hosted at https://79.127.136.196:38791